### PR TITLE
Jtamplin 2024

### DIFF
--- a/index.html
+++ b/index.html
@@ -93,7 +93,7 @@
             2340 Center St<br/>
             Chattanooga, TN 37421<br/>
           </p>
-          <h4>Room Reservations</h4>
+          <h3>Room Reservations</h3>
           <ul>
             <li><a target="_blank" href="https://bit.ly/crgc-2024-ri">King
               Suite - $119/night</a><br/>
@@ -124,7 +124,7 @@
           railroad theme, we play it!</p>
 
           <p>As in the past, we will have two separate tournaments plus open
-          gaming from Thursday morning until Monday morning. We hope to have a
+          gaming from Thursday morning until Sunday evening. We hope to have a
           special Thursday night event for the early birds plus some special
           surprises as we gather annually for what has been called “train gamer
           heaven”. Learn new games or play old favorites. New games start every

--- a/index.html
+++ b/index.html
@@ -1,4 +1,4 @@
-he<!doctype html>
+<!doctype html>
 <html lang="en">
   <head>
     <!-- Required meta tags -->

--- a/index.html
+++ b/index.html
@@ -97,10 +97,10 @@
           <dl>
             <dt><a target="_blank" href="https://bit.ly/crgc-2024-ri">King
               Suite - $119/night</a></dt>
-              <dd></dd>Residence Inn</dd>
+              <dd>Residence Inn</dd>
             <dt><a target="_blank" href="https://bit.ly/crgc-2024-tp">Queen
-              Studio - $99/night</dt>
-            <dd></dd>TownePlace Suites</dd>
+              Studio - $99/night</a></dt>
+            <dd>TownePlace Suites</dd>
           </dl>
           <h3>Prices</h3>
           <p>

--- a/index.html
+++ b/index.html
@@ -75,7 +75,7 @@
         </div>
         <div class="col-md-9" >
           <h1>
-            <span>27th Annual</span>
+            <span>28th Annual</span>
             Chattanooga Rail Gaming Challenge
           </h1>
         </div>
@@ -83,41 +83,52 @@
       <div class="row justify-content-center">
         <div class="col-md-3 text-md-right">
           <h3>Date</h3>
-          <p>25-29th January 2023</p>
+          <p>11-14th January 2024</p>
           <h3>Registration</h3>
-          <p><a target="_blank" href="https://forms.gle/6eN18dJb9ipeQyJn7">Registration Form</a></a></p>
+          <p>Registration Form coming soon</p>
           <h3>Location</h3>
           <p>
-            <a target="_blank" href="https://bit.ly/2023-crgc-hotel">Embassy Suites</a><br/>
-            Hamilton Place Mall<br/>
-            I-75 @ Exit 5<br/>
-            Chattanooga, TN<br/>
-            <i class="fa fa-phone"></i> <a href="tel:4236025100">423.602.5100</a><br/>
-            Group Rate Code: <strong>CESCRG</strong>
+            Residence Inn by Marriott</a><br/>
+            Chattanooga near Hamilton Place<br/>
+            2340 Center St<br/>
+            Chattanooga, TN 37421<br/>
           </p>
+          <h4>Room Reservations</h4>
+          <p>To get the convention rate (and for us to get credit for it), you <b><i>must</i></b> make the reservation
+          through the links below.  There are limited rooms, particularly the queen suites and on Sunday night, so if
+          you have any difficulty please <a href="mailto:jat@deepthoughtgames.com">Email me</a> so I can get them to
+          add more rooms.  The room block expires December 11.</p>
+          <p>Since we're on the hook if insufficient room nights are held, there will be a drawing for all the people who
+            are currently registered in the hotel room blocks on September 15, 2023 - the prize is one free entry for
+          the tournament (refunded if already paid).</p>
+          <ul>
+            <li><a target="_blank" href="https://urldefense.com/v3/__https://www.marriott.com/events/start.mi?id=1691780295548&key=GRP__;!!FOfmI8qiWcWBHqypJtzENF0!zSiZvz0QbZpY9wuycHpGXzBq2Q9I2B25xXc6iHOAj4mK40Q69_jylB2Eg8xOQDDEpkJUROlym9GlOEPF_BYrMU3yIv5L1jkX2N8$">King
+              Suites - $119/night at Residence Inn</a></li>
+            <li><a target="_blank" href="https://urldefense.com/v3/__https://www.marriott.com/events/start.mi?id=1691780554934&key=GRP__;!!FOfmI8qiWcWBHqypJtzENF0!xZLLBonRjRwVPlTV0vikpu9MFDxFQq9VdiEvaA-xKQeGNPWUzlS2A3rv4NNvOPY_slknjPPo6vpBheISsVReOTRBxNN6_hhIKTg$">2-Queen
+              Suites - $99/night at TownePlace Suites</a><br/>
+              These rooms are at a sister hotel that shares the same parking lot, so it is not as convient to the event
+              space but a bit cheaper and has two queen beds.
+            </li>
+          </ul>
           <h3>Prices</h3>
           <p>
-            <strong>$65</strong> in advance (check)<br/>
-            <strong>$75</strong> on site<br/>
-            <strong>$20</strong> single day<br/>
-            <i>Prices subject to change</i>
+            <strong>$90</strong> in advance<br/>
+            <strong>$100</strong> on site<br/>
+            <strong>$30</strong> single day<br/>
           </p>
           <h3>Contact</h3>
           <address>
-            Mark Derrick<br/>
-            8601 Glenaire Drive<br/>
-            Chattanooga, TN<br/>
-            37416-1546<br/>
-            <i class="fa fa-envelope"></i> <a href="mailto:railbaron@epbfi.com">railbaron@epbfi.com</a><br/>
+            John Tamplin<br/>
+            4116 Manson Ave<br/>
+            Smryna, GA 30082-3723<br/>
+            <i class="fa fa-envelope"></i> <a href="mailto:jat@deepthoughtgames.com">jat@deepthoughtgames.com</a><br/>
           
           </address>
         </div>
         <div class="col-md-9">
           <p>Come to the longest running rail gaming convention in the southeast
-          as we celebrate our 27<sup>th</sup> year! If it’s a game with a
-          railroad theme, we play it! We will have a large meeting space within
-          a brand new ballroom and draw lovers of train games every year from as
-          far away as Europe!</p>
+          as we celebrate our 28<sup>th</sup> year! If it’s a game with a
+          railroad theme, we play it!</p>
 
           <p>As in the past, we will have two separate tournaments plus open
           gaming from Thursday morning until Monday morning. We hope to have a
@@ -125,17 +136,6 @@
           surprises as we gather annually for what has been called “train gamer
           heaven”. Learn new games or play old favorites. New games start every
           hour and new players are welcome*.</p>
-
-          <p>
-            Rooms are available at a discounted rate and includes a take-away breakfast!
-            Contact the <a target="_blank"
-            href="https://bit.ly/2023-crgc-hotel">Embassy
-            Suites</a> directly at <a href="tel:4236027556">423/602-7556</a> and ask for
-            Jackie Galbreath to
-            book using group rate code <mark>CESCRG</mark>.
-          </p>
-          
-          <p><a target="_blank" href="https://forms.gle/6eN18dJb9ipeQyJn7">Registration Form</a></p>
 
           <p>Save the Date and See You There!</p>
 

--- a/index.html
+++ b/index.html
@@ -94,15 +94,14 @@
             Chattanooga, TN 37421<br/>
           </p>
           <h3>Room Reservations</h3>
-          <ul>
-            <li><a target="_blank" href="https://bit.ly/crgc-2024-ri">King
-              Suite - $119/night</a><br/>
-              Residence Inn
-            </li>
-            <li><a target="_blank" href="https://bit.ly/crgc-2024-tp">Queen
-              Studio - $99/night</a><br/>
-            TownePlace Suites</li>
-          </ul>
+          <dl>
+            <dt><a target="_blank" href="https://bit.ly/crgc-2024-ri">King
+              Suite - $119/night</a></dt>
+              <dd></dd>Residence Inn</dd>
+            <dt><a target="_blank" href="https://bit.ly/crgc-2024-tp">Queen
+              Studio - $99/night</dt>
+            <dd></dd>TownePlace Suites</dd>
+          </dl>
           <h3>Prices</h3>
           <p>
             <strong>$90</strong> in advance<br/>

--- a/index.html
+++ b/index.html
@@ -85,17 +85,18 @@
           <h3>Date</h3>
           <p>11-14th January 2024</p>
           <h3>Registration</h3>
-          <p><div><a target="_blank" href="">Registration Form</a><br/>
+          <div><a target="_blank" href="">Registration Form</a><br/>
             <form action="https://www.paypal.com/cgi-bin/webscr" method="post" target="_top">
               <input type="hidden" name="cmd" value="_s-xclick" />
               <input type="hidden" name="hosted_button_id" value="8NXN36QUVHSDQ" />
               <input type="hidden" name="currency_code" value="USD" />
               <input type="image" src="https://www.paypalobjects.com/en_US/i/btn/btn_paynow_LG.gif" border="0" name="submit" title="PayPal - The safer, easier way to pay online!" alt="Pay Now" />
             </form>
-          </div></p>
+          </div><br/>
           <h3>Location</h3>
           <p>
-            Residence Inn by Marriott</a><br/>
+            <a target="_blank" href="https://www.google.com/maps/dir//Residence+Inn+by+Marriott+Chattanooga+Near+Hamilton+Place,+2340+Center+St,+Chattanooga,+TN+37421/@35.0465642,-85.1582356,15z/data=!4m9!4m8!1m0!1m5!1m1!1s0x8860639a0721b293:0xdc43c01c5f62dbfd!2m2!1d-85.1582356!2d35.0465642!3e0?entry=ttu">Residence
+              Inn by Marriott</a><br/>
             near Hamilton Place<br/>
             2340 Center St<br/>
             Chattanooga, TN 37421<br/>
@@ -103,21 +104,21 @@
           <h3>Room Reservations</h3>
           <dl>
             <dt><a target="_blank" href="https://bit.ly/crgc-2024-ri">King
-              Suite - $119/night<sup>&dagger;</sup></a></dt>
+              Suite - $119/night</a><sup>&dagger;</sup></dt>
               <dd>Residence Inn</dd>
             <dt><a target="_blank" href="https://bit.ly/crgc-2024-tp">Queen
-              Studio - $99/night<sup>&dagger;</sup></a></dt>
+              Studio - $99/night</a><sup>&dagger;</sup></dt>
             <dd>TownePlace Suites</dd>
           </dl>
-          <br/><small><sup>&dagger;</sup><i> plus taxes</i></small><p></p>
-          <h3>Prices</h3>
+          <small><sup>&dagger;</sup><i> plus taxes</i></small><p></p>
+          <h3>Admission</h3>
           <p>
-            <strong>$103</strong><sup>&Dagger;</sup> in advance<br/>
-            <strong>$99</strong><sup>&Dagger;</sup> mail a check<br/>
-            <strong>$110</strong><sup>&Dagger;</sup> on-site<br/>
-            <strong>$30</strong><sup>&Dagger;</sup> single day<br/>
-          <br/>
-          <small><sup>&Dagger;</sup><i> Includes TN sales tax</i></small></p>
+            <strong>$103</strong><sup> &Dagger;</sup> in advance<br/>
+            <strong>$99</strong><sup> &Dagger;</sup> mail a check<br/>
+            <strong>$110</strong><sup> &Dagger;</sup> on-site<br/>
+            <strong>$35</strong><sup> &Dagger;</sup> single day<br/>
+            <small><sup>&Dagger;</sup><i> Includes TN sales tax</i></small>
+          </p>
           <h3>Contact</h3>
           <address>
             Deep Thought Games, LLC<br/>
@@ -137,19 +138,27 @@
           surprises as we gather annually for what has been called “train gamer
           heaven”. Learn new games or play old favorites. New games start every
           hour and new players are welcome<sup>*</sup>.</p>
-          
+
+     	    <p>The cost for meeting space is higher so the admission fee has to go
+            up, but the rooms are cheaper so the overall cost of attending will be cheaper.
+          </p>
+
           <p>To get the convention rate (and for us to get credit for it), you <b><i>must</i></b> make the reservation
           through the links on the left.  There are limited rooms, particularly the queen suites and on Sunday night, so if
-          you have any difficulty please <a href="mailto:jat@deepthoughtgames.com">Email me</a> so I can get them to
-          add more rooms.  The room block expires December 11.</p>
+          you have any difficulty registering the dates you want please <a href="mailto:jat@deepthoughtgames.com">email me</a>
+          so I can get them to add more rooms.  The room block expires December 11.</p>
+          
           <p>Since we're on the hook if insufficient room nights are sold, there will be a drawing for all the people who
             are currently registered in the hotel room blocks on September 15, 2023 - the prize is one free entry for
           the tournament (refunded if already paid).</p>
+          
           <p>The Residence Inn only has suites with one King bed and a sofa bed available, so we also added rooms at the
             sister hotel, TownePlace Suites, across the parking lot.  These have 2 queen beds and are cheaper, but it is
-            a short walk to where the convention is held - it might be inconvenient in bad weather.<p>
+            a short walk to where the convention is held - it might be inconvenient in bad weather.</p>
 
-          <p>If paying online, register first them come back here and pay using PayPal.</p>
+          <p>If paying online, register first them come back here and pay using PayPal - just paying does not get you
+            registered.</p>
+          
           <p>Save the Date and See You There!</p>
 
           <p><em>* Not responsible for profound regret from choosing not to attend.</em></p>

--- a/index.html
+++ b/index.html
@@ -85,14 +85,14 @@
           <h3>Date</h3>
           <p>11-14th January 2024</p>
           <h3>Registration</h3>
-          <p><a target="_blank" href="">Registration Form</a><br/>
+          <div><a target="_blank" href="">Registration Form</a><br/>
             <form action="https://www.paypal.com/cgi-bin/webscr" method="post" target="_top">
               <input type="hidden" name="cmd" value="_s-xclick" />
               <input type="hidden" name="hosted_button_id" value="8NXN36QUVHSDQ" />
               <input type="hidden" name="currency_code" value="USD" />
               <input type="image" src="https://www.paypalobjects.com/en_US/i/btn/btn_paynow_LG.gif" border="0" name="submit" title="PayPal - The safer, easier way to pay online!" alt="Pay Now" />
             </form>
-          </p>
+          </div>
           <h3>Location</h3>
           <p>
             Residence Inn by Marriott</a><br/>
@@ -109,15 +109,15 @@
               Studio - $99/night<sup>&dagger;</sup></a></dt>
             <dd>TownePlace Suites</dd>
           </dl>
-          <p><sup>&dagger;</sup> plus taxes</p>
+          <p><sup>&dagger;</sup><i> plus taxes</i></p>
           <h3>Prices</h3>
           <p>
-            <strong>$103</strong><sup>&dagger;</sup> in advance<br/>
-            <strong>$99</strong><sup>&dagger;</sup> mail a check<br/>
-            <strong>$110</strong><sup>&dagger;</sup> on-site<br/>
-            <strong>$30</strong><sup>&dagger;</sup> single day<br/>
+            <strong>$103</strong><sup>&Dagger;</sup> in advance<br/>
+            <strong>$99</strong><sup>&Dagger;</sup> mail a check<br/>
+            <strong>$110</strong><sup>&Dagger;</sup> on-site<br/>
+            <strong>$30</strong><sup>&Dagger;</sup> single day<br/>
           </p>
-          <p><sup>&Dagger;</sup> Includes TN sales tax</p>
+          <p><sup>&Dagger;</sup><i> Includes TN sales tax</i></p>
           <h3>Contact</h3>
           <address>
             Deep Thought Games, LLC<br/>

--- a/index.html
+++ b/index.html
@@ -95,9 +95,11 @@
           </p>
           <h4>Room Reservations</h4>
           <ul>
-            <li><a target="_blank" href="https://urldefense.com/v3/__https://www.marriott.com/events/start.mi?id=1691780295548&key=GRP__;!!FOfmI8qiWcWBHqypJtzENF0!zSiZvz0QbZpY9wuycHpGXzBq2Q9I2B25xXc6iHOAj4mK40Q69_jylB2Eg8xOQDDEpkJUROlym9GlOEPF_BYrMU3yIv5L1jkX2N8$">King
-              Suite - $119/night</a></li>
-            <li><a target="_blank" href="https://urldefense.com/v3/__https://www.marriott.com/events/start.mi?id=1691780554934&key=GRP__;!!FOfmI8qiWcWBHqypJtzENF0!xZLLBonRjRwVPlTV0vikpu9MFDxFQq9VdiEvaA-xKQeGNPWUzlS2A3rv4NNvOPY_slknjPPo6vpBheISsVReOTRBxNN6_hhIKTg$">Queen
+            <li><a target="_blank" href="https://bit.ly/crgc-2024-ri">King
+              Suite - $119/night</a><br/>
+              Residence Inn
+            </li>
+            <li><a target="_blank" href="https://bit.ly/crgc-2024-tp">Queen
               Studio - $99/night</a><br/>
             TownePlace Suites</li>
           </ul>
@@ -126,7 +128,7 @@
           special Thursday night event for the early birds plus some special
           surprises as we gather annually for what has been called “train gamer
           heaven”. Learn new games or play old favorites. New games start every
-          hour and new players are welcome*.</p>
+          hour and new players are welcome<sup>*</sup>.</p>
           
           <p>To get the convention rate (and for us to get credit for it), you <b><i>must</i></b> make the reservation
           through the links on the left.  There are limited rooms, particularly the queen suites and on Sunday night, so if

--- a/index.html
+++ b/index.html
@@ -85,14 +85,14 @@
           <h3>Date</h3>
           <p>11-14th January 2024</p>
           <h3>Registration</h3>
-          <div><a target="_blank" href="">Registration Form</a><br/>
+          <p></p><div><a target="_blank" href="">Registration Form</a><br/>
             <form action="https://www.paypal.com/cgi-bin/webscr" method="post" target="_top">
               <input type="hidden" name="cmd" value="_s-xclick" />
               <input type="hidden" name="hosted_button_id" value="8NXN36QUVHSDQ" />
               <input type="hidden" name="currency_code" value="USD" />
               <input type="image" src="https://www.paypalobjects.com/en_US/i/btn/btn_paynow_LG.gif" border="0" name="submit" title="PayPal - The safer, easier way to pay online!" alt="Pay Now" />
             </form>
-          </div>
+          </div></p>
           <h3>Location</h3>
           <p>
             Residence Inn by Marriott</a><br/>
@@ -101,7 +101,7 @@
             Chattanooga, TN 37421<br/>
           </p>
           <h3>Room Reservations</h3>
-          <dl>
+          <p><dl>
             <dt><a target="_blank" href="https://bit.ly/crgc-2024-ri">King
               Suite - $119/night<sup>&dagger;</sup></a></dt>
               <dd>Residence Inn</dd>
@@ -109,15 +109,15 @@
               Studio - $99/night<sup>&dagger;</sup></a></dt>
             <dd>TownePlace Suites</dd>
           </dl>
-          <p><sup>&dagger;</sup><i> plus taxes</i></p>
+          <br/><sup>&dagger;</sup><i> plus taxes</i></p>
           <h3>Prices</h3>
           <p>
             <strong>$103</strong><sup>&Dagger;</sup> in advance<br/>
             <strong>$99</strong><sup>&Dagger;</sup> mail a check<br/>
             <strong>$110</strong><sup>&Dagger;</sup> on-site<br/>
             <strong>$30</strong><sup>&Dagger;</sup> single day<br/>
-          </p>
-          <p><sup>&Dagger;</sup><i> Includes TN sales tax</i></p>
+          <br/>
+          <sup>&Dagger;</sup><i> Includes TN sales tax</i></p>
           <h3>Contact</h3>
           <address>
             Deep Thought Games, LLC<br/>

--- a/index.html
+++ b/index.html
@@ -85,7 +85,15 @@
           <h3>Date</h3>
           <p>11-14th January 2024</p>
           <h3>Registration</h3>
-          <p><i>Coming soon...</i></p>
+          <p><a target="_blank" href="">Registration Form</a></p>
+          <p>
+            <form action="https://www.paypal.com/cgi-bin/webscr" method="post" target="_top">
+              <input type="hidden" name="cmd" value="_s-xclick" />
+              <input type="hidden" name="hosted_button_id" value="8NXN36QUVHSDQ" />
+              <input type="hidden" name="currency_code" value="USD" />
+              <input type="image" src="https://www.paypalobjects.com/en_US/i/btn/btn_paynow_LG.gif" border="0" name="submit" title="PayPal - The safer, easier way to pay online!" alt="Pay Now" />
+            </form>
+          </p>
           <h3>Location</h3>
           <p>
             Residence Inn by Marriott</a><br/>
@@ -96,18 +104,21 @@
           <h3>Room Reservations</h3>
           <dl>
             <dt><a target="_blank" href="https://bit.ly/crgc-2024-ri">King
-              Suite - $119/night</a></dt>
+              Suite - $119/night&dagger;</a></dt>
               <dd>Residence Inn</dd>
             <dt><a target="_blank" href="https://bit.ly/crgc-2024-tp">Queen
-              Studio - $99/night</a></dt>
+              Studio - $99/night&dagger;</a></dt>
             <dd>TownePlace Suites</dd>
           </dl>
+          <p>&dagger; plus taxes</p>
           <h3>Prices</h3>
           <p>
-            <strong>$90</strong> in advance<br/>
-            <strong>$100</strong> on-site<br/>
-            <strong>$30</strong> single day<br/>
+            <strong>$103&Dagger;</strong> in advance<br/>
+            <strong>$99&Dagger;</strong> mail a check<br/>
+            <strong>$110&Dagger;</strong> on-site<br/>
+            <strong>$30&Dagger</strong> single day<br/>
           </p>
+          <p>&Dagger; Includes TN sales tax</p>
           <h3>Contact</h3>
           <address>
             John Tamplin<br/>
@@ -140,6 +151,7 @@
             sister hotel, TownePlace Suites, across the parking lot.  These have 2 queen beds and are cheaper, but it is
             a short walk to where the convention is held - it might be inconvenient in bad weather.<p>
 
+          <p>If paying online, register first them come back here and pay using PayPal.</p>
           <p>Save the Date and See You There!</p>
 
           <p><em>* Not responsible for profound regret from choosing not to attend.</em></p>

--- a/index.html
+++ b/index.html
@@ -85,8 +85,7 @@
           <h3>Date</h3>
           <p>11-14th January 2024</p>
           <h3>Registration</h3>
-          <p><a target="_blank" href="">Registration Form</a></p>
-          <p>
+          <p><a target="_blank" href="">Registration Form</a><br/>
             <form action="https://www.paypal.com/cgi-bin/webscr" method="post" target="_top">
               <input type="hidden" name="cmd" value="_s-xclick" />
               <input type="hidden" name="hosted_button_id" value="8NXN36QUVHSDQ" />
@@ -104,28 +103,27 @@
           <h3>Room Reservations</h3>
           <dl>
             <dt><a target="_blank" href="https://bit.ly/crgc-2024-ri">King
-              Suite - $119/night&dagger;</a></dt>
+              Suite - $119/night<sup>&dagger;</sup></a></dt>
               <dd>Residence Inn</dd>
             <dt><a target="_blank" href="https://bit.ly/crgc-2024-tp">Queen
-              Studio - $99/night&dagger;</a></dt>
+              Studio - $99/night<sup>&dagger;</sup></a></dt>
             <dd>TownePlace Suites</dd>
           </dl>
-          <p>&dagger; plus taxes</p>
+          <p><sup>&dagger;</sup> plus taxes</p>
           <h3>Prices</h3>
           <p>
-            <strong>$103&Dagger;</strong> in advance<br/>
-            <strong>$99&Dagger;</strong> mail a check<br/>
-            <strong>$110&Dagger;</strong> on-site<br/>
-            <strong>$30&Dagger</strong> single day<br/>
+            <strong>$103</strong><sup>&dagger;</sup> in advance<br/>
+            <strong>$99</strong><sup>&dagger;</sup> mail a check<br/>
+            <strong>$110</strong><sup>&dagger;</sup> on-site<br/>
+            <strong>$30</strong><sup>&dagger;</sup> single day<br/>
           </p>
-          <p>&Dagger; Includes TN sales tax</p>
+          <p><sup>&Dagger;</sup> Includes TN sales tax</p>
           <h3>Contact</h3>
           <address>
-            John Tamplin<br/>
+            Deep Thought Games, LLC<br/>
             4116 Manson Ave<br/>
             Smryna, GA 30082-3723<br/>
             <i class="fa fa-envelope"></i> <a href="mailto:jat@deepthoughtgames.com">jat@deepthoughtgames.com</a><br/>
-          
           </address>
         </div>
         <div class="col-md-9">

--- a/index.html
+++ b/index.html
@@ -104,20 +104,19 @@
           <h3>Room Reservations</h3>
           <dl>
             <dt><a target="_blank" href="https://bit.ly/crgc-2024-ri">King
-              Suite - $119/night</a><sup>&dagger;</sup></dt>
+              Suite - $119/night</a></dt>
               <dd>Residence Inn</dd>
             <dt><a target="_blank" href="https://bit.ly/crgc-2024-tp">Queen
-              Studio - $99/night</a><sup>&dagger;</sup></dt>
+              Studio - $99/night</a></dt>
             <dd>TownePlace Suites</dd>
           </dl>
-          <small><sup>&dagger;</sup><i> plus taxes</i></small><p></p>
           <h3>Admission</h3>
           <p>
-            <strong>$103</strong><sup> &Dagger;</sup> in advance<br/>
-            <strong>$99</strong><sup> &Dagger;</sup> mail a check<br/>
-            <strong>$110</strong><sup> &Dagger;</sup> on-site<br/>
-            <strong>$35</strong><sup> &Dagger;</sup> single day<br/>
-            <small><sup>&Dagger;</sup><i> Includes TN sales tax</i></small>
+            <strong>$103</strong><sup> &dagger;</sup> in advance<br/>
+            <strong>$99</strong><sup> &dagger;</sup> mail a check<br/>
+            <strong>$110</strong><sup> &dagger;</sup> on-site<br/>
+            <strong>$35</strong><sup> &dagger;</sup> single day<br/>
+            <small><sup>&dagger;</sup><i> Includes TN sales tax</i></small>
           </p>
           <h3>Contact</h3>
           <address>
@@ -132,7 +131,8 @@
           as we celebrate our 28<sup>th</sup> year! If it’s a game with a
           railroad theme, we play it!</p>
 
-          <p>As in the past, we will have two separate tournaments plus open
+          <p>As in the past, we will have 18xx and <a target="_blank" href="https://www.traingamers.com/">Puffing
+            Billy</a> tournaments plus open
           gaming from Thursday morning until Sunday evening. We hope to have a
           special Thursday night event for the early birds plus some special
           surprises as we gather annually for what has been called “train gamer

--- a/index.html
+++ b/index.html
@@ -156,7 +156,7 @@
             sister hotel, TownePlace Suites, across the parking lot.  These have 2 queen beds and are cheaper, but it is
             a short walk to where the convention is held - it might be inconvenient in bad weather.</p>
 
-          <p>If paying online, register first them come back here and pay using PayPal - just paying does not get you
+          <p>If paying online, register first. Then come back here and pay using PayPal - just paying does not get you
             registered.</p>
           
           <p>Save the Date and See You There!</p>

--- a/index.html
+++ b/index.html
@@ -85,7 +85,7 @@
           <h3>Date</h3>
           <p>11-14th January 2024</p>
           <h3>Registration</h3>
-          <p></p><div><a target="_blank" href="">Registration Form</a><br/>
+          <p><div><a target="_blank" href="">Registration Form</a><br/>
             <form action="https://www.paypal.com/cgi-bin/webscr" method="post" target="_top">
               <input type="hidden" name="cmd" value="_s-xclick" />
               <input type="hidden" name="hosted_button_id" value="8NXN36QUVHSDQ" />
@@ -101,7 +101,7 @@
             Chattanooga, TN 37421<br/>
           </p>
           <h3>Room Reservations</h3>
-          <p><dl>
+          <dl>
             <dt><a target="_blank" href="https://bit.ly/crgc-2024-ri">King
               Suite - $119/night<sup>&dagger;</sup></a></dt>
               <dd>Residence Inn</dd>
@@ -109,7 +109,7 @@
               Studio - $99/night<sup>&dagger;</sup></a></dt>
             <dd>TownePlace Suites</dd>
           </dl>
-          <br/><sup>&dagger;</sup><i> plus taxes</i></p>
+          <br/><small><sup>&dagger;</sup><i> plus taxes</i></small><p></p>
           <h3>Prices</h3>
           <p>
             <strong>$103</strong><sup>&Dagger;</sup> in advance<br/>
@@ -117,7 +117,7 @@
             <strong>$110</strong><sup>&Dagger;</sup> on-site<br/>
             <strong>$30</strong><sup>&Dagger;</sup> single day<br/>
           <br/>
-          <sup>&Dagger;</sup><i> Includes TN sales tax</i></p>
+          <small><sup>&Dagger;</sup><i> Includes TN sales tax</i></small></p>
           <h3>Contact</h3>
           <address>
             Deep Thought Games, LLC<br/>

--- a/index.html
+++ b/index.html
@@ -1,4 +1,4 @@
-<!doctype html>
+he<!doctype html>
 <html lang="en">
   <head>
     <!-- Required meta tags -->
@@ -98,7 +98,8 @@
             <li><a target="_blank" href="https://urldefense.com/v3/__https://www.marriott.com/events/start.mi?id=1691780295548&key=GRP__;!!FOfmI8qiWcWBHqypJtzENF0!zSiZvz0QbZpY9wuycHpGXzBq2Q9I2B25xXc6iHOAj4mK40Q69_jylB2Eg8xOQDDEpkJUROlym9GlOEPF_BYrMU3yIv5L1jkX2N8$">King
               Suite - $119/night</a></li>
             <li><a target="_blank" href="https://urldefense.com/v3/__https://www.marriott.com/events/start.mi?id=1691780554934&key=GRP__;!!FOfmI8qiWcWBHqypJtzENF0!xZLLBonRjRwVPlTV0vikpu9MFDxFQq9VdiEvaA-xKQeGNPWUzlS2A3rv4NNvOPY_slknjPPo6vpBheISsVReOTRBxNN6_hhIKTg$">Queen
-              Studio - $99/night<sup><b>*</b></sup></a></li>
+              Studio - $99/night</a><br/>
+            TownePlace Suites</li>
           </ul>
           <h3>Prices</h3>
           <p>
@@ -135,8 +136,8 @@
             are currently registered in the hotel room blocks on September 15, 2023 - the prize is one free entry for
           the tournament (refunded if already paid).</p>
           <p>The Residence Inn only has suites with one King bed and a sofa bed available, so we also added rooms at the
-            sister hotel, TownePlace Suites, across the parking lot.  These have 2 queen beds and it is a short walk to
-            where the convention is held, so it might be inconvenient in bad weather.<p>
+            sister hotel, TownePlace Suites, across the parking lot.  These have 2 queen beds and are cheaper, but it is
+            a short walk to where the convention is held - it might be inconvenient in bad weather.<p>
 
           <p>Save the Date and See You There!</p>
 

--- a/index.html
+++ b/index.html
@@ -85,20 +85,20 @@
           <h3>Date</h3>
           <p>11-14th January 2024</p>
           <h3>Registration</h3>
-          <p>Registration Form coming soon</p>
+          <p><i>Coming soon...</i></p>
           <h3>Location</h3>
           <p>
             Residence Inn by Marriott</a><br/>
-            Chattanooga near Hamilton Place<br/>
+            near Hamilton Place<br/>
             2340 Center St<br/>
             Chattanooga, TN 37421<br/>
           </p>
           <h4>Room Reservations</h4>
           <ul>
             <li><a target="_blank" href="https://urldefense.com/v3/__https://www.marriott.com/events/start.mi?id=1691780295548&key=GRP__;!!FOfmI8qiWcWBHqypJtzENF0!zSiZvz0QbZpY9wuycHpGXzBq2Q9I2B25xXc6iHOAj4mK40Q69_jylB2Eg8xOQDDEpkJUROlym9GlOEPF_BYrMU3yIv5L1jkX2N8$">King
-              Suites - $119/night at Residence Inn</a></li>
-            <li><a target="_blank" href="https://urldefense.com/v3/__https://www.marriott.com/events/start.mi?id=1691780554934&key=GRP__;!!FOfmI8qiWcWBHqypJtzENF0!xZLLBonRjRwVPlTV0vikpu9MFDxFQq9VdiEvaA-xKQeGNPWUzlS2A3rv4NNvOPY_slknjPPo6vpBheISsVReOTRBxNN6_hhIKTg$">2-Queen
-              Studio - $99/night at TownePlace Suites</a></li>
+              Suite - $119/night</a></li>
+            <li><a target="_blank" href="https://urldefense.com/v3/__https://www.marriott.com/events/start.mi?id=1691780554934&key=GRP__;!!FOfmI8qiWcWBHqypJtzENF0!xZLLBonRjRwVPlTV0vikpu9MFDxFQq9VdiEvaA-xKQeGNPWUzlS2A3rv4NNvOPY_slknjPPo6vpBheISsVReOTRBxNN6_hhIKTg$">Queen
+              Studio - $99/night<sup><b>*</b></sup></a></li>
           </ul>
           <h3>Prices</h3>
           <p>
@@ -131,7 +131,7 @@
           through the links on the left.  There are limited rooms, particularly the queen suites and on Sunday night, so if
           you have any difficulty please <a href="mailto:jat@deepthoughtgames.com">Email me</a> so I can get them to
           add more rooms.  The room block expires December 11.</p>
-          <p>Since we're on the hook if insufficient room nights are held, there will be a drawing for all the people who
+          <p>Since we're on the hook if insufficient room nights are sold, there will be a drawing for all the people who
             are currently registered in the hotel room blocks on September 15, 2023 - the prize is one free entry for
           the tournament (refunded if already paid).</p>
           <p>The Residence Inn only has suites with one King bed and a sofa bed available, so we also added rooms at the

--- a/index.html
+++ b/index.html
@@ -94,26 +94,16 @@
             Chattanooga, TN 37421<br/>
           </p>
           <h4>Room Reservations</h4>
-          <p>To get the convention rate (and for us to get credit for it), you <b><i>must</i></b> make the reservation
-          through the links below.  There are limited rooms, particularly the queen suites and on Sunday night, so if
-          you have any difficulty please <a href="mailto:jat@deepthoughtgames.com">Email me</a> so I can get them to
-          add more rooms.  The room block expires December 11.</p>
-          <p>Since we're on the hook if insufficient room nights are held, there will be a drawing for all the people who
-            are currently registered in the hotel room blocks on September 15, 2023 - the prize is one free entry for
-          the tournament (refunded if already paid).</p>
           <ul>
             <li><a target="_blank" href="https://urldefense.com/v3/__https://www.marriott.com/events/start.mi?id=1691780295548&key=GRP__;!!FOfmI8qiWcWBHqypJtzENF0!zSiZvz0QbZpY9wuycHpGXzBq2Q9I2B25xXc6iHOAj4mK40Q69_jylB2Eg8xOQDDEpkJUROlym9GlOEPF_BYrMU3yIv5L1jkX2N8$">King
               Suites - $119/night at Residence Inn</a></li>
             <li><a target="_blank" href="https://urldefense.com/v3/__https://www.marriott.com/events/start.mi?id=1691780554934&key=GRP__;!!FOfmI8qiWcWBHqypJtzENF0!xZLLBonRjRwVPlTV0vikpu9MFDxFQq9VdiEvaA-xKQeGNPWUzlS2A3rv4NNvOPY_slknjPPo6vpBheISsVReOTRBxNN6_hhIKTg$">2-Queen
-              Suites - $99/night at TownePlace Suites</a><br/>
-              These rooms are at a sister hotel that shares the same parking lot, so it is not as convient to the event
-              space but a bit cheaper and has two queen beds.
-            </li>
+              Studio - $99/night at TownePlace Suites</a></li>
           </ul>
           <h3>Prices</h3>
           <p>
             <strong>$90</strong> in advance<br/>
-            <strong>$100</strong> on site<br/>
+            <strong>$100</strong> on-site<br/>
             <strong>$30</strong> single day<br/>
           </p>
           <h3>Contact</h3>
@@ -136,6 +126,17 @@
           surprises as we gather annually for what has been called “train gamer
           heaven”. Learn new games or play old favorites. New games start every
           hour and new players are welcome*.</p>
+          
+          <p>To get the convention rate (and for us to get credit for it), you <b><i>must</i></b> make the reservation
+          through the links on the left.  There are limited rooms, particularly the queen suites and on Sunday night, so if
+          you have any difficulty please <a href="mailto:jat@deepthoughtgames.com">Email me</a> so I can get them to
+          add more rooms.  The room block expires December 11.</p>
+          <p>Since we're on the hook if insufficient room nights are held, there will be a drawing for all the people who
+            are currently registered in the hotel room blocks on September 15, 2023 - the prize is one free entry for
+          the tournament (refunded if already paid).</p>
+          <p>The Residence Inn only has suites with one King bed and a sofa bed available, so we also added rooms at the
+            sister hotel, TownePlace Suites, across the parking lot.  These have 2 queen beds and it is a short walk to
+            where the convention is held, so it might be inconvenient in bad weather.<p>
 
           <p>Save the Date and See You There!</p>
 


### PR DESCRIPTION
This updates the page for 2024, including new hotel links and verbiage.  This will need to get pushed to the website roughly at the same time that Mark sends out an announcement that he is stepping down running the tournament, presumably in the next few days.